### PR TITLE
all: replace links to sourcegraph master to main

### DIFF
--- a/resources/user-data.sh
+++ b/resources/user-data.sh
@@ -46,7 +46,7 @@ mkcert -cert-file ${SOURCEGRAPH_CONFIG}/sourcegraph.crt -key-file ${SOURCEGRAPH_
 # Configure the nginx.conf file for SSL.
 #
 cat > ${SOURCEGRAPH_CONFIG}/nginx.conf <<EOL
-# From https://github.com/sourcegraph/sourcegraph/blob/master/cmd/server/shared/assets/nginx.conf
+# From https://github.com/sourcegraph/sourcegraph/blob/main/cmd/server/shared/assets/nginx.conf
 # You can adjust the configuration to add additional TLS or HTTP features.
 # Read more at https://docs.sourcegraph.com/admin/nginx
 


### PR DESCRIPTION
We no longer use the master branch and one day will delete it.

Test Plan: CI

[_Created by Sourcegraph batch change `keegan/update-master-links`._](https://k8s.sgdev.org/users/keegan/batch-changes/update-master-links)